### PR TITLE
t/02-unload.t - test for syntax error

### DIFF
--- a/t/02-unload.t
+++ b/t/02-unload.t
@@ -6,7 +6,7 @@ use Test::More tests => 9;
 use Quote::Ref ();
 
 is eval('qwa]1]'), undef;
-like $@, qr/Number found where operator/;
+like $@, qr/syntax error/;
 
 {
 	use Quote::Ref;
@@ -14,7 +14,7 @@ like $@, qr/Number found where operator/;
 }
 
 is eval('qwa]1]'), undef;
-like $@, qr/Number found where operator/;
+like $@, qr/syntax error/;
 
 use Quote::Ref;
 is_deeply qwa]1], [qw]1]];
@@ -22,7 +22,7 @@ is_deeply qwa]1], [qw]1]];
 {
 	no Quote::Ref;
 	is eval('qwa]1]'), undef;
-	like $@, qr/Number found where operator/;
+	like $@, qr/syntax error/;
 }
 
 is_deeply qwa]1], [qw]1]];


### PR DESCRIPTION
The first error the compiler produces is a syntax error, so test for it instead of the numeric error, which might not be visible in a newer perl.

See also: https://github.com/Perl/perl5/issues/20346